### PR TITLE
Allow env var to override Pelican config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Please ensure a `requirements.txt` is present for your site and installs
 ## Environment variables
 
   - `GH_PAGES_BRANCH` (optional): override the default `gh-pages` deployment branch
+  - `PELICAN_CONFIG_FILE` (optional): override the default `pelicanconf.py` config file
 
 ## History
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts && \
 echo "${GIT_DEPLOY_KEY}" > /root/.ssh/id_rsa && \
 chmod 400 /root/.ssh/id_rsa
 echo '=================== Build site ==================='
-pelican content -o output -s pelicanconf.py
+pelican content -o output -s ${PELICAN_CONFIG_FILE:=pelicanconf.py}
 echo '=================== Publish to GitHub Pages ==================='
 cd output
 # shellcheck disable=SC2012


### PR DESCRIPTION
It is common to use `pelicanconf.py` for local development and then `publishconf.py` for production (see [the docs][1])- allowing this to be configurable lets people manage multiple Pelican configs as required.

  [1]: https://docs.getpelican.com/en/stable/publish.html#deployment