### PR TITLE
add npm to required install in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
 
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt-get install -y nodejs
+RUN apt-get install -y nodejs npm
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
I haven't tested this yet, but I was getting build failures because npm wasn't installed

```
Installing Node Modules 🧰 
/github/workspace/mine /github/workspace
/entrypoint.sh: line 17: npm: command not found
```
