### PR TITLE
Bump python and Node versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.12-slim
 
 LABEL "com.github.actions.name"="Pelican for GitHub Pages"
 LABEL "com.github.actions.description"="Builds and deploys the Pelican project to GitHub Pages"
@@ -12,12 +12,35 @@ ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
+# Install node via instructions at https://github.com/nodesource/distributions
 RUN apt-get update \
-    && apt-get install --no-install-recommends -qy git curl bash
-
-
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+    && apt-get install --no-install-recommends -qy git curl bash ca-certificates gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
 RUN apt-get install -y nodejs npm
+
+# Pre-requisites for Pillow, a key requirement for many python-based pelican installs.
+# Per https://pillow.readthedocs.io/en/stable/installation.html#
+RUN apt-get install -y \
+    libffi-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libharfbuzz-dev \
+    libjpeg-turbo-progs \
+    libjpeg62-turbo-dev \
+    liblcms2-dev \
+    libopenjp2-7-dev \
+    libtiff5-dev \
+    libwebp-dev \
+    libssl-dev \
+    meson \
+    netpbm \
+    tcl8.6-dev \
+    tk8.6-dev \
+    xvfb \
+    zlib1g-dev 
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Update to use Node installation method, per directions in the nag in the script used previously.

Update to python 3.12, with pre-installed depdendencies for Pillow, per their install docs.